### PR TITLE
Simplify Error Handling

### DIFF
--- a/Recognition/src/commands.c
+++ b/Recognition/src/commands.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <error.h>
 #include "commands.h"
 
 // PROTOTYPES *****************
@@ -23,8 +24,8 @@ char *get_command(char *database,char *speech) {
   char *ret = NULL; // The command to return.
 
   if(! file_exists(database)) {
-    printf("The database \"%s\" doesn't exist!\n",database);
-    exit(2);
+  fprintf(stderr,"The database \"%s\" doesn't exist!\n",database);
+  exit(EXIT_FAILURE);
   }
 
   file = fopen(database,"r");
@@ -66,8 +67,8 @@ char *create_command(char *buf) {
   /* printf("%s\n",buf); */
   char *ret = malloc(sizeof(char)*1024); // get a kilo at a time
   if(ret == NULL) {
-    printf("Memory problems in create command!\n");
-    exit(1);
+  perror("malloc:");
+  exit(EXIT_FAILURE);
   }
   int i = 0;
   char saveChar;
@@ -77,8 +78,8 @@ char *create_command(char *buf) {
 
   // First skip leading spaces
   if(*buf != ' ' && *buf != '\t') {
-    printf("This line does not start with a space!\n");
-    exit(1);
+    fprintf(stderr,"This line does not start with a space!\n");
+    exit(EXIT_FAILURE);
   }
   while(*buf == ' ' || *buf == '\t') {
     ++buf;
@@ -88,15 +89,15 @@ char *create_command(char *buf) {
     if( i % 1023) {
       ret = realloc(ret,sizeof(char)*1024*((i/1023)+1));
       if(ret == NULL) {
-      	printf("Memory problems in create command!\n");
-      	exit(1);
+      	perror("malloc:");
+      	exit(EXIT_FAILURE);
       }
     }
     if(*buf == '\\') {
       buf++;
       if(*buf == '\n' || *buf == '\0' || *buf == '\r') {
-      	printf("Error, '\\' char at the end\n");
-      	exit(1);
+        fprintf(stderr,"Error, '\\' char at the end\n");
+      	exit(EXIT_FAILURE);
       }
       ret[i] = *buf;
     }
@@ -106,7 +107,7 @@ char *create_command(char *buf) {
       ++buf;
       if(*buf == '$' || *buf == '\n' || *buf == '\0' || *buf == '\r') {
       	printf("Bad syntax in create command!\n");
-      	exit(1);
+      	exit(EXIT_FAILURE);
       }
       startVarName = buf;
       while(*buf != '$' && *buf != '\n' && *buf != '\0' && *buf != '\r') {
@@ -114,8 +115,8 @@ char *create_command(char *buf) {
       }
 
       if(*buf != '$') {
-      	printf("Bad syntax in create command!\n");
-      	exit(1);
+        fprintf(stderr,"Bad syntax in create command!\n");
+      	exit(EXIT_FAILURE);
       }
 
       saveChar = *buf;
@@ -137,8 +138,8 @@ char *create_command(char *buf) {
       	    if( i % 1023) {
       	      ret = realloc(ret,sizeof(char)*1024*((i/1023)+1));
       	      if(ret == NULL) {
-            		printf("Memory problems in create command!\n");
-            		exit(1);
+            		perror("malloc:");
+            		exit(EXIT_FAILURE);
       	      }
       	    }
 
@@ -171,8 +172,8 @@ void store_special_variables(char *speech,char *buf) {
     // first time add special var $SPEECH$
     var_LL = malloc(1*sizeof(struct variables));
     if(var_LL == NULL) {
-      printf("Memory Error in op_match!\n");
-      exit(1);
+      perror("malloc:");
+      exit(EXIT_FAILURE);
     }
     // Set the var_Header to access the head later.
     var_Header = var_LL;
@@ -183,7 +184,7 @@ void store_special_variables(char *speech,char *buf) {
     var_LL->varValue = malloc(strlen(speech)+1);
     strcpy(var_LL->varValue,speech);
   } else {
-    printf("var_LL is not null!!\n");
+    fprintf(stderr,"var_LL is not null!!\n");
     exit(1);
   }
 

--- a/Recognition/src/dictionary.c
+++ b/Recognition/src/dictionary.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
   char *command = NULL; // The command to run.
   
   if(parse_args(argc,argv,&speech,&database) != 0) {
-    exit(1);
+    exit(EXIT_FAILURE);
   }
   command = get_command(database,speech);
 
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
     }
     
   } else {
-    printf("No Command recognized.\n");
+    fprintf(stderr,"No Command recognized.\n");
     exit(2);
   }
 
@@ -149,17 +149,16 @@ int parse_args(int argc,char *argv[],char **speech,char **database) {
     return 1;
   }
   if(*speech != NULL || *database != NULL) {
-    printf("ERROR, speech and database pointers must be NULL\n"
-	   "before calling parse_args().");
+    fprintf(stderr,"ERROR, speech and database pointers must be NULL\n"
+	    "before calling parse_args().");
     return 1;
   }
   *speech = malloc(sizeof(char)*strlen(argv[1])+1);
   *database = malloc(sizeof(char)*strlen(argv[2])+1);
 
   if(*speech == NULL || *database == NULL) {
-    printf("Memory error in allocating strings to hold speech \n"
-	   "and database.");
-    exit(1);
+   perror("malloc:");
+   exit(EXIT_FAILURE);
   }
   strcpy(*speech,argv[1]);
   strcpy(*database,argv[2]);
@@ -169,8 +168,8 @@ int parse_args(int argc,char *argv[],char **speech,char **database) {
     
     sscanf(argv[3],"%d",&i);
     if(i <= 0) {
-      printf("'%s' is not a valid line to start on.\n",argv[3]);
-      exit(1);
+      fprintf(stderr,"'%s' is not a valid line to start on.\n",argv[3]);
+      exit(EXIT_FAILURE);
     }
     LINE_IN_DATABASE = i-1;
 


### PR DESCRIPTION
I have simplified error handling in cases where malloc failed by using perror. All errors will now be sent to the error stream.
