### PR TITLE
Update dictionary.c

### DIFF
--- a/Recognition/src/dictionary.c
+++ b/Recognition/src/dictionary.c
@@ -62,7 +62,7 @@ static int is_there_enough_args(int argc);
 // ie. testing 1 2 3
 // becomes
 // testing '1 2 3'
-void print_arg_quoted(char *string);
+static void print_arg_quoted(char *string);
 
 int main(int argc, char *argv[]) {
   


### PR DESCRIPTION
Fixed a compilation error of dictionary.c on my 32bit Ubuntu. Here's the compilation log:

gcc -O3 src/dictionary.c src/match.c src/commands.c -o dictionary
src/dictionary.c:104:13: error: static declaration of ‘print_arg_quoted’ follows non-static declaration
src/dictionary.c:65:6: note: previous declaration of ‘print_arg_quoted’ was here
src/commands.c: In function ‘get_command’:
src/commands.c:50:12: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]
make: **\* [dictionary] Error 1
