### PR TITLE
User dictionary location/name fix

### DIFF
--- a/Doc/Plugins/Example Plugins/UserInformation (Uses the new SDK)/plugin.info
+++ b/Doc/Plugins/Example Plugins/UserInformation (Uses the new SDK)/plugin.info
@@ -6,4 +6,4 @@ author = Brett Mayson
 description = Get User Information
 actions =
 whats my ip, Display the users ip address
-whats my name, Display the users name (as set in .pavaler.d/UserInfo)
+whats my name, Display the users name (as set in .palaver.d/UserInfo)

--- a/Microphone/osd_server.py
+++ b/Microphone/osd_server.py
@@ -14,7 +14,7 @@ PWD=str(os.getcwd()) # Our full path
 def transText(text):
 	text = text.replace("\n",'')
 	home = subprocess.Popen("echo $HOME", shell=True, stdout=subprocess.PIPE).communicate()[0].replace('\n','')
-	with open(home+"/.pavaler.d/UserInfo") as f:
+	with open(home+"/.palaver.d/UserInfo") as f:
 		for each in f:
 			line = each.replace('\n','')
 			if line.startswith("LANG="):

--- a/Recognition/bin/edit_details
+++ b/Recognition/bin/edit_details
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gedit "$HOME/.pavaler.d/UserInfo"
+gedit "$HOME/.palaver.d/UserInfo"

--- a/Recognition/config/Gmail/settings.conf
+++ b/Recognition/config/Gmail/settings.conf
@@ -1,4 +1,4 @@
 #Add your gmail login info
-#This program uses the same email under ~/.pavaler.d/UserInfo
+#This program uses the same email under ~/.palaver.d/UserInfo
 #It will only work with gmail accounts
 password=

--- a/recognize
+++ b/recognize
@@ -14,7 +14,7 @@
    #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # TODO, make this use the mode, context and custom sed script
 
-USER_DIR=$HOME/.pavaler.d
+USER_DIR=$HOME/.palaver.d
 
 # Try to run a command in ./Recognition/bin with useful errors.
 function run_command() {

--- a/sdk
+++ b/sdk
@@ -30,7 +30,7 @@ if args.c != '':
 	os.system("chmod +x "+pdir+"bin/"+args.c)
 	os.system("touch "+pdir+"config/settings.conf")
 	#Create plugin.info
-	with open(home+"/.pavaler.d/UserInfo") as f:
+	with open(home+"/.palaver.d/UserInfo") as f:
 		for l in f:
 			if l.startswith("FIRST="):
 				first = l.replace("FIRST=",'').replace("\n",'')

--- a/setup
+++ b/setup
@@ -17,9 +17,9 @@ touch Recognition/dictionary.c
 cd Recognition
 make
 cd ..
-mkdir $HOME/.pavaler.d/
-cp Recognition/config/BlankInfo $HOME/.pavaler.d/UserInfo
-nano $HOME/.pavaler.d/UserInfo
+mkdir $HOME/.palaver.d/
+cp Recognition/config/BlankInfo $HOME/.palaver.d/UserInfo
+nano $HOME/.palaver.d/UserInfo
 
 echo "Done, you will have to setup the hotkey yourself."
 


### PR DESCRIPTION
Hi!
So I started using Palaver (which is great BTW), and noticed that at a lot of places inside the tutorials and in _the code that generates the directory in the user's home, you use the name "pavaler"_ (e.g.: the crearted directory will be ~/.pavaler.d, in the code references to ~/.pavaler.d). 

The code itself works, of course, but as this program is name Palaver as far as I know, it is a bit confusing. So what I did is _I modified the setup script and every references, so now the folder is called '.palaver.d' (eg.: ~/.palaver.d). I also modified the references in the tutorials/guides, so it stays consistent._
